### PR TITLE
Add header to input and output files

### DIFF
--- a/deferred-annotation-reconstructor.py
+++ b/deferred-annotation-reconstructor.py
@@ -33,7 +33,7 @@ groupO.add_argument("warcfile", nargs='?', type=str, help="WARC file used to ret
 # Optional parameter
 parser.add_argument("--limit_sentences", type=int, help="Limit number of fully reconstructed sentence pairs")
 # Optional indexes and header
-parser.add_argument("--header", action='store_true', help="If set, the input file will be expected to contain a header")
+parser.add_argument("--header", action='store_true', help="If set, the input file will be expected to contain a header and it will be printed")
 parser.add_argument("--src_url_idx", type=int if not header else str, default=0 if not header else "src_url", help="Source URL index")
 parser.add_argument("--trg_url_idx", type=int if not header else str, default=1 if not header else "trg_url", help="Target URL index")
 parser.add_argument("--src_deferred_idx", type=int if not header else str, default=5 if not header else "src_deferred_hash", help="Source sentence deferred index")
@@ -54,6 +54,8 @@ with gzip.open(args.bitextor_output, 'rt') as bitextor_output:
         trg_deferred_idx = header.index(trg_deferred_idx)
         src_url_idx = header.index(src_url_idx)
         trg_url_idx = header.index(trg_url_idx)
+
+        print('\t'.join(header))
 
     reconst_count = 0  # Let's count how many sentences have been fully reconstructed (both source and target are not empty)
     for line in bitextor_output:

--- a/deferred-annotation-reconstructor.py
+++ b/deferred-annotation-reconstructor.py
@@ -36,8 +36,8 @@ parser.add_argument("--limit_sentences", type=int, help="Limit number of fully r
 parser.add_argument("--header", action='store_true', help="If set, the input file will be expected to contain a header")
 parser.add_argument("--src_url_idx", type=int if not header else str, default=0 if not header else "src_url", help="Source URL index")
 parser.add_argument("--trg_url_idx", type=int if not header else str, default=1 if not header else "trg_url", help="Target URL index")
-parser.add_argument("--src_deferred_idx", type=int if not header else str, default="src_deferred_hash", help="Source sentence deferred index")
-parser.add_argument("--trg_deferred_idx", type=int if not header else str, default="trg_deferred_hash", help="Target sentence deferred index")
+parser.add_argument("--src_deferred_idx", type=int if not header else str, default=5 if not header else "src_deferred_hash", help="Source sentence deferred index")
+parser.add_argument("--trg_deferred_idx", type=int if not header else str, default=6 if not header else "trg_deferred_hash", help="Target sentence deferred index")
 
 args = parser.parse_args()
 

--- a/deferred-annotation-reconstructor.py
+++ b/deferred-annotation-reconstructor.py
@@ -31,6 +31,10 @@ groupO = parser.add_argument_group('optional positional arguments')
 groupO.add_argument("warcfile", nargs='?', type=str, help="WARC file used to retrieve documents. If a document is not found, then wget will try to download it")
 # Optional parameter
 parser.add_argument("--limit_sentences", type=int, help="Limit number of fully reconstructed sentence pairs")
+parser.add_argument("--src_url_idx", type=int, default=0, help="Source URL index")
+parser.add_argument("--trg_url_idx", type=int, default=1, help="Target URL index")
+parser.add_argument("--src_deferred_idx", type=int, default=5, help="Source sentence deferred index")
+parser.add_argument("--trg_deferred_idx", type=int, default=6, help="Target sentence deferred index")
 
 args = parser.parse_args()
 
@@ -39,10 +43,10 @@ with gzip.open(args.bitextor_output, 'rt') as bitextor_output:
     for line in bitextor_output:
         # Parse bitextor ".sent.gz" line with deferred crawling annotations
         parts_line = line.rstrip('\n').split('\t')
-        deferredhash1 = parts_line[5]
-        deferredhash2 = parts_line[6]
-        url1 = parts_line[0]
-        url2 = parts_line[1]
+        deferredhash1 = parts_line[args.src_deferred_idx]
+        deferredhash2 = parts_line[args.trg_deferred_idx]
+        url1 = parts_line[args.src_url_idx]
+        url2 = parts_line[args.trg_url_idx]
         reconst_parts_line = []  # Store the content of the reconstructed line in another list for a post processing checks and counts
         reconst_parts_line += [url1,url2]
         


### PR DESCRIPTION
The input file will have to contain a header which describes each column, and an output header will be printed. These headers are optional. Changes:

- Flag `--header` has to be set in order to expect the header fields in the input file. If set, the output header will be printed as well.
- New flags `--src_url_idx`, `--trg_url_idx`, `--src_deferred_idx` and `--trg_deferred_idx` in order to specify the position or header field name of the columns of the input file. The flags will expect header fields instead of positions if `--header` is set.

These changes have been tested with the Bitextor CI tests.